### PR TITLE
🐛 rich-pixels bugs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
   "rich-click~=1.5.2",
   "rich-pixels~=2.1.1",
   "textual~=0.22.3",
-  "universal-pathlib~=0.0.21"
+  "universal-pathlib~=0.0.21",
+  "Pillow~=9.1.0"
 ]
 description = "TUI File Browser App"
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "rich-pixels~=2.1.1",
   "textual~=0.22.3",
   "universal-pathlib~=0.0.21",
-  "Pillow~=9.1.0"
+  "Pillow>=9.1.0"
 ]
 description = "TUI File Browser App"
 dynamic = ["version"]

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1069,7 +1069,9 @@ pillow==9.5.0 \
     --hash=sha256:fbd359831c1657d69bb81f0db962905ee05e5e9451913b18b831febfe0519082 \
     --hash=sha256:fe7e1c262d3392afcf5071df9afa574544f28eac825284596ac6db56e6d11062 \
     --hash=sha256:fed1e1cf6a42577953abbe8e6cf2fe2f566daebde7c34724ec8803c4c0cda579
-    # via rich-pixels
+    # via
+    #   -r requirements.in
+    #   rich-pixels
 pip-tools==6.13.0 \
     --hash=sha256:50943f151d87e752abddec8158622c34ad7f292e193836e90e30d87da60b19d9 \
     --hash=sha256:61d46bd2eb8016ed4a924e196e6e5b0a268cd3babd79e593048720db23522bb1

--- a/requirements/requirements-prod.txt
+++ b/requirements/requirements-prod.txt
@@ -797,7 +797,9 @@ pillow==9.5.0 \
     --hash=sha256:fbd359831c1657d69bb81f0db962905ee05e5e9451913b18b831febfe0519082 \
     --hash=sha256:fe7e1c262d3392afcf5071df9afa574544f28eac825284596ac6db56e6d11062 \
     --hash=sha256:fed1e1cf6a42577953abbe8e6cf2fe2f566daebde7c34724ec8803c4c0cda579
-    # via rich-pixels
+    # via
+    #   -r requirements.in
+    #   rich-pixels
 portalocker==2.7.0 \
     --hash=sha256:032e81d534a88ec1736d03f780ba073f047a06c478b06e2937486f334e955c51 \
     --hash=sha256:a07c5b4f3985c3cf4798369631fb7011adb498e2a46d8440efc75a8f29a0f983


### PR DESCRIPTION
A problem in rich-pixels caused this error `ImportError: cannot import name 'Resampling' from 'PIL.Image'` this commit fixes it by requiring Pillow `Pillow>=9.1.0`