### PR TITLE
🐛 Do not import requests if not available

### DIFF
--- a/browsr/_utils.py
+++ b/browsr/_utils.py
@@ -9,7 +9,11 @@ from dataclasses import dataclass
 from typing import Any, BinaryIO, Dict, Optional, Union
 
 import fitz  # type: ignore[import]
-import requests
+
+try:
+    import requests
+except ImportError:
+    pass
 import rich_pixels
 from fitz import Pixmap
 from PIL import Image


### PR DESCRIPTION
The app currently does not work when installed without any optional dependencies. 
This is caused by requests module always being imported even though it is optional.

`pipx install browsr`

```
browsr .
Traceback (most recent call last):
  File "/home/mhoyer/.local/bin/browsr", line 5, in <module>
    from browsr.__main__ import browsr
  File "/home/mhoyer/.local/pipx/venvs/browsr/lib64/python3.11/site-packages/browsr/__init__.py", line 5, in <module>
    from .browsr import Browsr
  File "/home/mhoyer/.local/pipx/venvs/browsr/lib64/python3.11/site-packages/browsr/browsr.py", line 30, in <module>
    from browsr._base import (
  File "/home/mhoyer/.local/pipx/venvs/browsr/lib64/python3.11/site-packages/browsr/_base.py", line 28, in <module>
    from browsr._utils import FileInfo, handle_github_url
  File "/home/mhoyer/.local/pipx/venvs/browsr/lib64/python3.11/site-packages/browsr/_utils.py", line 12, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```
